### PR TITLE
implement three dot menu

### DIFF
--- a/frontend/app/(tabs)/favorites.tsx
+++ b/frontend/app/(tabs)/favorites.tsx
@@ -11,6 +11,7 @@ import { useTheme } from '../contexts/ThemeContext';
 import { useFavoriteCards } from '../hooks/useCards';
 import { useInfiniteScroll } from '../hooks/useInfiniteScroll';
 import { useCardActions } from '../hooks/useCardActions';
+import { CardData } from '../types/card';
 
 const Favorites = () => {
   const { colors } = useTheme();
@@ -79,7 +80,7 @@ const Favorites = () => {
       >
         {cards.length === 0 && !isLoading
           ? renderNoFavorites()
-          : cards.map((card) => (
+          : cards.map((card: CardData) => (
               <Card
                 key={card.id}
                 item={card}

--- a/frontend/app/components/CardFront.tsx
+++ b/frontend/app/components/CardFront.tsx
@@ -1,7 +1,8 @@
-import React from 'react';
-import { Text, TouchableOpacity, View } from 'react-native';
+import React, { useState } from 'react';
+import { Text, TouchableOpacity, View, Alert, Share } from 'react-native';
 import Animated, { AnimatedStyle } from 'react-native-reanimated';
 import { Ionicons } from '@expo/vector-icons';
+import * as Clipboard from 'expo-clipboard';
 import { CardData } from '../types/card';
 import { ViewStyle, GestureResponderEvent } from 'react-native';
 import { useTheme } from '../contexts/ThemeContext';
@@ -29,72 +30,284 @@ const CardFront: React.FC<CardFrontProps> = ({
   CARD_HEIGHT,
 }) => {
   const { colors } = useTheme();
+  const [menuVisible, setMenuVisible] = useState(false);
+
+  const toggleMenu = (e: GestureResponderEvent) => {
+    e.stopPropagation();
+    setMenuVisible((prev) => !prev);
+  };
+
+  const closeMenu = () => {
+    setMenuVisible(false);
+  };
+
+  const handleShare = async (e: GestureResponderEvent) => {
+    e.stopPropagation();
+    try {
+      await Share.share({
+        message: `"${item.text}" - ${item.meaning}`,
+        title: 'Share Idiom',
+      });
+      closeMenu();
+    } catch (error) {
+      console.log('Error sharing:', error);
+      closeMenu();
+    }
+  };
+
+  const handleViewStats = (e: GestureResponderEvent) => {
+    e.stopPropagation();
+    Alert.alert(
+      'Idiom Statistics',
+      `Frequency: ${item.frequency_of_use}/10\nUpvotes: ${item.upvotes}\nDownvotes: ${item.downvotes}\nLiteral Transparency: ${item.literal_transparency}/10\nTranslation Difficulty: ${item.translation_difficulty}/10`,
+      [{ text: 'Close', style: 'default' }],
+    );
+    closeMenu();
+  };
+
+  const handleCopyText = async (e: GestureResponderEvent) => {
+    e.stopPropagation();
+    try {
+      await Clipboard.setStringAsync(item.text);
+      Alert.alert('Copied!', 'Text copied to clipboard.');
+      closeMenu();
+    } catch (error) {
+      console.log('Error copying:', error);
+      closeMenu();
+    }
+  };
+
+  const handleReportError = (e: GestureResponderEvent) => {
+    e.stopPropagation();
+    Alert.alert(
+      'Report Error',
+      'Thank you for helping us improve. What type of error would you like to report?',
+      [
+        {
+          text: 'Translation Error',
+          onPress: () => console.log('Translation error reported'),
+        },
+        {
+          text: 'Content Error',
+          onPress: () => console.log('Content error reported'),
+        },
+        {
+          text: 'Technical Issue',
+          onPress: () => console.log('Technical issue reported'),
+        },
+        { text: 'Cancel', style: 'cancel' },
+      ],
+    );
+    closeMenu();
+  };
 
   return (
-    <Animated.View
-      style={[
-        {
-          width: CARD_WIDTH,
-          height: CARD_HEIGHT,
-          backgroundColor: colors.cardBackground,
-          borderRadius: 20,
-          padding: 24,
-          justifyContent: 'center',
-          alignItems: 'center',
-          position: 'absolute',
-          shadowColor: colors.shadowColor,
-          shadowOffset: { width: 0, height: 4 },
-          shadowOpacity: 0.2,
-          shadowRadius: 6,
-          elevation: 5,
-        },
-        frontAnimatedStyle,
-      ]}
-    >
-      <View className="flex-1 justify-center items-center w-full">
-        <Text
-          style={{ color: colors.text }}
-          className="text-3xl font-extrabold text-center mb-6"
+    <>
+      <Animated.View
+        style={[
+          {
+            width: CARD_WIDTH,
+            height: CARD_HEIGHT,
+            backgroundColor: colors.cardBackground,
+            borderRadius: 20,
+            padding: 24,
+            justifyContent: 'center',
+            alignItems: 'center',
+            position: 'absolute',
+            shadowColor: colors.shadowColor,
+            shadowOffset: { width: 0, height: 4 },
+            shadowOpacity: 0.2,
+            shadowRadius: 6,
+            elevation: 5,
+          },
+          frontAnimatedStyle,
+        ]}
+      >
+        <TouchableOpacity
+          onPress={toggleMenu}
+          style={{
+            position: 'absolute',
+            top: 16,
+            right: 16,
+            padding: 8,
+            backgroundColor: 'rgba(0,0,0,0.1)',
+            borderRadius: 20,
+            zIndex: 1000,
+          }}
+          hitSlop={{ top: 10, bottom: 10, left: 10, right: 10 }}
+          activeOpacity={0.7}
         >
-          {item.text}
-        </Text>
+          <Ionicons name="ellipsis-vertical" size={20} color={colors.text} />
+        </TouchableOpacity>
 
-        <SmileyDisplay smileys={item.depiction} />
-      </View>
+        <View className="flex-1 justify-center items-center w-full">
+          <Text
+            style={{ color: colors.text }}
+            className="text-3xl font-extrabold text-center mb-6"
+          >
+            {item.text}
+          </Text>
 
-      <TouchableOpacity
-        onPress={handleFavoritePress}
-        style={{
-          position: 'absolute',
-          bottom: CARD_HEIGHT * 0.05,
-          right: CARD_WIDTH * 0.05,
-          padding: 10,
-          backgroundColor: 'rgba(255,255,255,0.1)',
-          borderRadius: 999,
-        }}
-      >
-        <Ionicons
-          name={item.favorite ? 'star' : 'star-outline'}
-          size={28}
-          color={item.favorite ? '#FFD700' : colors.text}
-        />
-      </TouchableOpacity>
+          <SmileyDisplay smileys={item.depiction} />
+        </View>
 
-      <View
-        style={{
-          position: 'absolute',
-          bottom: CARD_HEIGHT * 0.05,
-          left: CARD_WIDTH * 0.05,
-        }}
-      >
-        <VotingButtons
-          cardId={item.id}
-          upvotes={item.upvotes}
-          downvotes={item.downvotes}
-          onVote={onVotePress}
-        />
-      </View>
-    </Animated.View>
+        <TouchableOpacity
+          onPress={handleFavoritePress}
+          style={{
+            position: 'absolute',
+            bottom: CARD_HEIGHT * 0.05,
+            right: CARD_WIDTH * 0.05,
+            padding: 10,
+            backgroundColor: 'rgba(255,255,255,0.1)',
+            borderRadius: 999,
+          }}
+        >
+          <Ionicons
+            name={item.favorite ? 'star' : 'star-outline'}
+            size={28}
+            color={item.favorite ? '#FFD700' : colors.text}
+          />
+        </TouchableOpacity>
+
+        <View
+          style={{
+            position: 'absolute',
+            bottom: CARD_HEIGHT * 0.05,
+            left: CARD_WIDTH * 0.05,
+          }}
+        >
+          <VotingButtons
+            cardId={item.id}
+            upvotes={item.upvotes}
+            downvotes={item.downvotes}
+            onVote={onVotePress}
+          />
+        </View>
+      </Animated.View>
+
+      {menuVisible && (
+        <View
+          style={{
+            position: 'absolute',
+            top: 0,
+            left: 0,
+            right: 0,
+            bottom: 0,
+            zIndex: 9999,
+          }}
+        >
+          <TouchableOpacity
+            style={{
+              flex: 1,
+              backgroundColor: 'rgba(0,0,0,0.3)',
+            }}
+            onPress={closeMenu}
+            activeOpacity={1}
+          />
+
+          <View
+            style={{
+              position: 'absolute',
+              top: 60,
+              right: 20,
+              backgroundColor: colors.cardBackground,
+              borderRadius: 12,
+              paddingVertical: 8,
+              minWidth: 160,
+              shadowColor: '#000',
+              shadowOffset: { width: 0, height: 4 },
+              shadowOpacity: 0.25,
+              shadowRadius: 8,
+              elevation: 15,
+              borderWidth: 1,
+              borderColor: 'rgba(255,255,255,0.1)',
+            }}
+          >
+            <TouchableOpacity
+              onPress={handleShare}
+              style={{
+                flexDirection: 'row',
+                alignItems: 'center',
+                paddingHorizontal: 16,
+                paddingVertical: 12,
+              }}
+              activeOpacity={0.7}
+            >
+              <Ionicons
+                name="share-outline"
+                size={18}
+                color={colors.text}
+                style={{ marginRight: 12 }}
+              />
+              <Text style={{ color: colors.text, fontSize: 16 }}>Share</Text>
+            </TouchableOpacity>
+
+            <TouchableOpacity
+              onPress={handleViewStats}
+              style={{
+                flexDirection: 'row',
+                alignItems: 'center',
+                paddingHorizontal: 16,
+                paddingVertical: 12,
+              }}
+              activeOpacity={0.7}
+            >
+              <Ionicons
+                name="stats-chart-outline"
+                size={18}
+                color={colors.text}
+                style={{ marginRight: 12 }}
+              />
+              <Text style={{ color: colors.text, fontSize: 16 }}>
+                View Stats
+              </Text>
+            </TouchableOpacity>
+
+            <TouchableOpacity
+              onPress={handleCopyText}
+              style={{
+                flexDirection: 'row',
+                alignItems: 'center',
+                paddingHorizontal: 16,
+                paddingVertical: 12,
+              }}
+              activeOpacity={0.7}
+            >
+              <Ionicons
+                name="copy-outline"
+                size={18}
+                color={colors.text}
+                style={{ marginRight: 12 }}
+              />
+              <Text style={{ color: colors.text, fontSize: 16 }}>
+                Copy Text
+              </Text>
+            </TouchableOpacity>
+
+            <TouchableOpacity
+              onPress={handleReportError}
+              style={{
+                flexDirection: 'row',
+                alignItems: 'center',
+                paddingHorizontal: 16,
+                paddingVertical: 12,
+              }}
+              activeOpacity={0.7}
+            >
+              <Ionicons
+                name="flag-outline"
+                size={18}
+                color={colors.text}
+                style={{ marginRight: 12 }}
+              />
+              <Text style={{ color: colors.text, fontSize: 16 }}>
+                Report Error
+              </Text>
+            </TouchableOpacity>
+          </View>
+        </View>
+      )}
+    </>
   );
 };
 

--- a/frontend/app/components/CardFront.tsx
+++ b/frontend/app/components/CardFront.tsx
@@ -2,12 +2,13 @@ import React, { useState } from 'react';
 import { Text, TouchableOpacity, View, Alert, Share } from 'react-native';
 import Animated, { AnimatedStyle } from 'react-native-reanimated';
 import { Ionicons } from '@expo/vector-icons';
-import * as Clipboard from 'expo-clipboard';
+import { setStringAsync } from 'expo-clipboard';
 import { CardData } from '../types/card';
 import { ViewStyle, GestureResponderEvent } from 'react-native';
 import { useTheme } from '../contexts/ThemeContext';
 import SmileyDisplay from './SmileyDisplay';
 import { VotingButtons } from './VotingButtons';
+import DropdownMenu from './DropdownMenu';
 
 interface CardFrontProps {
   item: CardData;
@@ -41,44 +42,35 @@ const CardFront: React.FC<CardFrontProps> = ({
     setMenuVisible(false);
   };
 
-  const handleShare = async (e: GestureResponderEvent) => {
-    e.stopPropagation();
+  const handleShare = async () => {
     try {
       await Share.share({
         message: `"${item.text}" - ${item.meaning}`,
         title: 'Share Idiom',
       });
-      closeMenu();
     } catch (error) {
       console.log('Error sharing:', error);
-      closeMenu();
     }
   };
 
-  const handleViewStats = (e: GestureResponderEvent) => {
-    e.stopPropagation();
+  const handleViewStats = () => {
     Alert.alert(
       'Idiom Statistics',
       `Frequency: ${item.frequency_of_use}/10\nUpvotes: ${item.upvotes}\nDownvotes: ${item.downvotes}\nLiteral Transparency: ${item.literal_transparency}/10\nTranslation Difficulty: ${item.translation_difficulty}/10`,
       [{ text: 'Close', style: 'default' }],
     );
-    closeMenu();
   };
 
-  const handleCopyText = async (e: GestureResponderEvent) => {
-    e.stopPropagation();
+  const handleCopyText = async () => {
     try {
-      await Clipboard.setStringAsync(item.text);
+      await setStringAsync(item.text);
       Alert.alert('Copied!', 'Text copied to clipboard.');
-      closeMenu();
     } catch (error) {
       console.log('Error copying:', error);
-      closeMenu();
     }
   };
 
-  const handleReportError = (e: GestureResponderEvent) => {
-    e.stopPropagation();
+  const handleReportError = () => {
     Alert.alert(
       'Report Error',
       'Thank you for helping us improve. What type of error would you like to report?',
@@ -98,8 +90,34 @@ const CardFront: React.FC<CardFrontProps> = ({
         { text: 'Cancel', style: 'cancel' },
       ],
     );
-    closeMenu();
   };
+
+  const menuItems = [
+    {
+      id: 'share',
+      label: 'Share',
+      icon: 'share-outline' as const,
+      onPress: handleShare,
+    },
+    {
+      id: 'stats',
+      label: 'View Stats',
+      icon: 'stats-chart-outline' as const,
+      onPress: handleViewStats,
+    },
+    {
+      id: 'copy',
+      label: 'Copy Text',
+      icon: 'copy-outline' as const,
+      onPress: handleCopyText,
+    },
+    {
+      id: 'report',
+      label: 'Report Error',
+      icon: 'flag-outline' as const,
+      onPress: handleReportError,
+    },
+  ];
 
   return (
     <>
@@ -185,128 +203,12 @@ const CardFront: React.FC<CardFrontProps> = ({
         </View>
       </Animated.View>
 
-      {menuVisible && (
-        <View
-          style={{
-            position: 'absolute',
-            top: 0,
-            left: 0,
-            right: 0,
-            bottom: 0,
-            zIndex: 9999,
-          }}
-        >
-          <TouchableOpacity
-            style={{
-              flex: 1,
-              backgroundColor: 'rgba(0,0,0,0.3)',
-            }}
-            onPress={closeMenu}
-            activeOpacity={1}
-          />
-
-          <View
-            style={{
-              position: 'absolute',
-              top: 60,
-              right: 20,
-              backgroundColor: colors.cardBackground,
-              borderRadius: 12,
-              paddingVertical: 8,
-              minWidth: 160,
-              shadowColor: '#000',
-              shadowOffset: { width: 0, height: 4 },
-              shadowOpacity: 0.25,
-              shadowRadius: 8,
-              elevation: 15,
-              borderWidth: 1,
-              borderColor: 'rgba(255,255,255,0.1)',
-            }}
-          >
-            <TouchableOpacity
-              onPress={handleShare}
-              style={{
-                flexDirection: 'row',
-                alignItems: 'center',
-                paddingHorizontal: 16,
-                paddingVertical: 12,
-              }}
-              activeOpacity={0.7}
-            >
-              <Ionicons
-                name="share-outline"
-                size={18}
-                color={colors.text}
-                style={{ marginRight: 12 }}
-              />
-              <Text style={{ color: colors.text, fontSize: 16 }}>Share</Text>
-            </TouchableOpacity>
-
-            <TouchableOpacity
-              onPress={handleViewStats}
-              style={{
-                flexDirection: 'row',
-                alignItems: 'center',
-                paddingHorizontal: 16,
-                paddingVertical: 12,
-              }}
-              activeOpacity={0.7}
-            >
-              <Ionicons
-                name="stats-chart-outline"
-                size={18}
-                color={colors.text}
-                style={{ marginRight: 12 }}
-              />
-              <Text style={{ color: colors.text, fontSize: 16 }}>
-                View Stats
-              </Text>
-            </TouchableOpacity>
-
-            <TouchableOpacity
-              onPress={handleCopyText}
-              style={{
-                flexDirection: 'row',
-                alignItems: 'center',
-                paddingHorizontal: 16,
-                paddingVertical: 12,
-              }}
-              activeOpacity={0.7}
-            >
-              <Ionicons
-                name="copy-outline"
-                size={18}
-                color={colors.text}
-                style={{ marginRight: 12 }}
-              />
-              <Text style={{ color: colors.text, fontSize: 16 }}>
-                Copy Text
-              </Text>
-            </TouchableOpacity>
-
-            <TouchableOpacity
-              onPress={handleReportError}
-              style={{
-                flexDirection: 'row',
-                alignItems: 'center',
-                paddingHorizontal: 16,
-                paddingVertical: 12,
-              }}
-              activeOpacity={0.7}
-            >
-              <Ionicons
-                name="flag-outline"
-                size={18}
-                color={colors.text}
-                style={{ marginRight: 12 }}
-              />
-              <Text style={{ color: colors.text, fontSize: 16 }}>
-                Report Error
-              </Text>
-            </TouchableOpacity>
-          </View>
-        </View>
-      )}
+      <DropdownMenu
+        visible={menuVisible}
+        onClose={closeMenu}
+        items={menuItems}
+        position={{ top: 60, right: 20 }}
+      />
     </>
   );
 };

--- a/frontend/app/components/DropdownMenu.tsx
+++ b/frontend/app/components/DropdownMenu.tsx
@@ -1,0 +1,103 @@
+import React from 'react';
+import { View, TouchableOpacity, Text } from 'react-native';
+import { Ionicons } from '@expo/vector-icons';
+import { useTheme } from '../contexts/ThemeContext';
+
+interface DropdownMenuItem {
+  id: string;
+  label: string;
+  icon: keyof typeof Ionicons.glyphMap;
+  onPress: () => void;
+}
+
+interface DropdownMenuProps {
+  visible: boolean;
+  onClose: () => void;
+  items: DropdownMenuItem[];
+  position?: {
+    top?: number;
+    right?: number;
+    left?: number;
+    bottom?: number;
+  };
+}
+
+export const DropdownMenu: React.FC<DropdownMenuProps> = ({
+  visible,
+  onClose,
+  items,
+  position = { top: 60, right: 20 },
+}) => {
+  const { colors } = useTheme();
+
+  if (!visible) return null;
+
+  return (
+    <View
+      style={{
+        position: 'absolute',
+        top: 0,
+        left: 0,
+        right: 0,
+        bottom: 0,
+        zIndex: 9999,
+      }}
+    >
+      <TouchableOpacity
+        style={{
+          flex: 1,
+          backgroundColor: 'rgba(0,0,0,0.3)',
+        }}
+        onPress={onClose}
+        activeOpacity={1}
+      />
+
+      <View
+        style={{
+          position: 'absolute',
+          ...position,
+          backgroundColor: colors.cardBackground,
+          borderRadius: 12,
+          paddingVertical: 8,
+          minWidth: 160,
+          shadowColor: '#000',
+          shadowOffset: { width: 0, height: 4 },
+          shadowOpacity: 0.25,
+          shadowRadius: 8,
+          elevation: 15,
+          borderWidth: 1,
+          borderColor: 'rgba(255,255,255,0.1)',
+        }}
+      >
+        {items.map((item) => (
+          <TouchableOpacity
+            key={item.id}
+            onPress={() => {
+              item.onPress();
+              onClose();
+            }}
+            style={{
+              flexDirection: 'row',
+              alignItems: 'center',
+              paddingHorizontal: 16,
+              paddingVertical: 12,
+            }}
+            activeOpacity={0.7}
+          >
+            <Ionicons
+              name={item.icon}
+              size={18}
+              color={colors.text}
+              style={{ marginRight: 12 }}
+            />
+            <Text style={{ color: colors.text, fontSize: 16 }}>
+              {item.label}
+            </Text>
+          </TouchableOpacity>
+        ))}
+      </View>
+    </View>
+  );
+};
+
+export default DropdownMenu;

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -15,6 +15,7 @@
         "@tanstack/react-query": "^5.80.7",
         "expo": "^52.0.43",
         "expo-blur": "~14.0.3",
+        "expo-clipboard": "^7.1.4",
         "expo-constants": "~17.0.8",
         "expo-font": "~13.0.4",
         "expo-haptics": "~14.0.1",
@@ -9186,6 +9187,16 @@
       "resolved": "https://registry.npmjs.org/expo-blur/-/expo-blur-14.0.3.tgz",
       "integrity": "sha512-BL3xnqBJbYm3Hg9t/HjNjdeY7N/q8eK5tsLYxswWG1yElISWZmMvrXYekl7XaVCPfyFyz8vQeaxd7q74ZY3Wrw==",
       "license": "MIT",
+      "peerDependencies": {
+        "expo": "*",
+        "react": "*",
+        "react-native": "*"
+      }
+    },
+    "node_modules/expo-clipboard": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/expo-clipboard/-/expo-clipboard-7.1.4.tgz",
+      "integrity": "sha512-NHhfKnrzb4o0PacUKD93ByadU0JmPBoFTFYbbFJZ9OAX6SImpSqG5gfrMUR3vVj4Qx9f1LpMcdAv5lBzv868ow==",
       "peerDependencies": {
         "expo": "*",
         "react": "*",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -24,6 +24,7 @@
     "@tanstack/react-query": "^5.80.7",
     "expo": "^52.0.43",
     "expo-blur": "~14.0.3",
+    "expo-clipboard": "^7.1.4",
     "expo-constants": "~17.0.8",
     "expo-font": "~13.0.4",
     "expo-haptics": "~14.0.1",


### PR DESCRIPTION
Implemented a modern three-dot menu feature for the card's front face in the React Native idioms app. The menu includes four key functionalities: Share (using native Share API to share the idiom text and meaning), View Stats (displaying detailed statistics like frequency, votes, and difficulty metrics in an alert), Copy Text (copying the idiom to clipboard using expo-clipboard), and Report Error (allowing users to report translation, content, or technical issues).